### PR TITLE
Style links, don't spellcheck, use port 4445

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -9,4 +9,4 @@ Check out our documentation at https://docs.rainway.com.
 ## Development
 
 1. Install dependencies: `npm install`
-2. Run `npm run dev` to launch a development server. Now go to `http://localhost:4443` in your browser.
+2. Run `npm run dev` to launch a development server. Now go to `http://localhost:4445` in your browser.

--- a/src/react-demo/Demo.tsx
+++ b/src/react-demo/Demo.tsx
@@ -154,6 +154,7 @@ export const Demo = () => {
       <input
         id="apiKey"
         type="text"
+        spellCheck={false}
         size={36}
         value={apiKey}
         disabled={runtime !== undefined || connectingRuntime}
@@ -194,6 +195,7 @@ export const Demo = () => {
           className="m-l-8"
           id="peerId"
           type="text"
+          spellCheck={false}
           value={peerId}
           placeholder="511111111111111111"
           disabled={!runtime || connecting}

--- a/src/react-demo/Widget.tsx
+++ b/src/react-demo/Widget.tsx
@@ -59,6 +59,7 @@ export const Widget = (props: WidgetProps) => {
         <input
           id="peerId"
           type="text"
+          spellCheck={false}
           value={props.peerId.toString()}
           disabled={true}
         />

--- a/src/style.css
+++ b/src/style.css
@@ -639,3 +639,14 @@ button.chat-send-button:disabled {
   width: 100%;
   height: 393px;
 }
+
+a {
+  color: var(--clr-primary-400);
+  font-weight: 600;
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+a:hover {
+  color: var(--clr-neutral-50);
+}

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -108,7 +108,7 @@ const config: webpack.Configuration & { devServer: any } = {
   devServer: {
     contentBase: outputPath,
     host: "0.0.0.0",
-    port: 4443,
+    port: 4445,
     disableHostCheck: true,
     inline: true,
     stats: "minimal",


### PR DESCRIPTION
I discovered the missing link style and spellcheck behavior by using the web demo in Safari.

I changed the default port to 4445 because our internal version of this demo runs at 4443 and this makes it easier for us Rainway devs to run both side-by-side :)